### PR TITLE
Add Obradovic,2023,ICAT to larics.bib

### DIFF
--- a/bibs/larics.bib
+++ b/bibs/larics.bib
@@ -4403,9 +4403,18 @@ abstract="Here we describe the mathematical model of the humanoid robot position
 isbn="978-981-99-3068-5"
 }
 
-
-
-
+@INPROCEEDINGS{Obradovic:2023,
+  author={Obradovic, Jura and Krizmancic, Marko and Bogdan, Stjepan},
+  booktitle={2023 International Conference on Information, Communication and Automation Technologies (ICAT)}, 
+  title={Decentralized Multi-Robot Formation Control Using Reinforcement Learning}, 
+  year={2023},
+  volume={},
+  number={},
+  pages={},
+  doi={},
+  location={Sarajevo, Bosnia and Herzegovina},
+  note={to appear}
+}
 
 
 


### PR DESCRIPTION
Added paper by Juraj Obradovic on ICAT 2023 in Sarajevo. It should be published in IEEEXplore soon.